### PR TITLE
Fix purge command in quickstart.sh on Debian

### DIFF
--- a/scripts/quickstart.sh
+++ b/scripts/quickstart.sh
@@ -334,7 +334,7 @@ function setup {
       echo -e "\nEnable Overcommit Memory"
       $PERMISSION_PREFIX  sysctl vm.overcommit_memory=1
     elif [ $PLATFORM_VARIENT == "Debian" ]; then
-      $PERMISSION_PREFIX purge ntp
+      $PERMISSION_PREFIX apt-get purge ntp
       $PERMISSION_PREFIX systemctl start systemd-timesyncd
     elif [[ $PLATFORM_VARIENT == "CentOS" ]] || [[ $PLATFORM_VARIENT == "Fedora" ]] || [[ $PLATFORM_VARIENT == "RHEL" ]] ; then
       $PERMISSION_PREFIX yum install -y ntp


### PR DESCRIPTION
Guess this should be `apt-get purge ntp`

```
Usage: apt-get [options] command
       apt-get [options] install|remove pkg1 [pkg2 ...]
       apt-get [options] source pkg1 [pkg2 ...]

apt-get is a command line interface for retrieval of packages
and information about them from authenticated sources and
for installation, upgrade and removal of packages together
with their dependencies.

Most used commands:
  update - Retrieve new lists of packages
  upgrade - Perform an upgrade
  install - Install new packages (pkg is libc6 not libc6.deb)
  reinstall - Reinstall packages (pkg is libc6 not libc6.deb)
  remove - Remove packages
  purge - Remove packages and config files
  autoremove - Remove automatically all unused packages
  dist-upgrade - Distribution upgrade, see apt-get(8)
  dselect-upgrade - Follow dselect selections
  build-dep - Configure build-dependencies for source packages
  clean - Erase downloaded archive files
  autoclean - Erase old downloaded archive files
  check - Verify that there are no broken dependencies
  source - Download source archives
  download - Download the binary package into the current directory
  changelog - Download and display the changelog for the given package
```