### PR TITLE
fix: Update quickstart.sh file for Nethermind

### DIFF
--- a/nethermind/quickstart.sh
+++ b/nethermind/quickstart.sh
@@ -531,11 +531,21 @@ function run() {
             --log-opt compress=true \
             --restart always \
             --memory "250m" \
-            $NETSTATS_DOCKER_IMAGE \
-            --network $NETWORK \
-            --instance-name $NODE_KEY \
-            --role ${ROLE^} \
-            --netstats-version $NETSTATS_VERSION
+            --env NODE_ENV=production \
+            --env RPC_HOST=$CONTAINER_NAME \
+            --env RPC_PORT=8545 \
+            --env LISTENING_PORT=30303 \
+            --env INSTANCE_NAME=$NODE_KEY \
+            --env ROLE=${ROLE^} \
+            --env BRIDGE_VERSION="" \
+            --env FUSE_APP_VERSION="" \
+            --env NETSTATS_VERSION=$NETSTATS_VERSION \
+            --env PARITY_VERSION="" \
+            --env CONTACT_DETAILS="" \
+            --env WS_SERVER="" \
+            --env WS_SECRET="" \
+            --env VERBOSITY=2 \
+            $NETSTATS_DOCKER_IMAGE
     fi
 
     if [[ $ROLE == "validator" ]]; then
@@ -582,12 +592,22 @@ function run() {
             --log-opt compress=true \
             --restart always \
             --memory "250m" \
-            $NETSTATS_DOCKER_IMAGE \
-            --network $NETWORK \
-            --instance-name "${NODE_KEY}_0x${PUBLIC_ADDRESS}" \
-            --role ${ROLE^} \
-            --netstats-version $NETSTATS_VERSION \
-            --fuseapp-version "1.0.0"
+            --env NODE_ENV=production \
+            --env RPC_HOST=$CONTAINER_NAME \
+            --env RPC_PORT=8545 \
+            --env LISTENING_PORT=30303 \
+            --env INSTANCE_NAME="${NODE_KEY}_0x${PUBLIC_ADDRESS}" \
+            --env ROLE=${ROLE^} \
+            --env BRIDGE_VERSION="" \
+            --env FUSE_APP_VERSION="1.0.0" \
+            --env NETSTATS_VERSION=$NETSTATS_VERSION \
+            --env PARITY_VERSION="" \
+            --env CONTACT_DETAILS="" \
+            --env WS_SERVER="" \
+            --env WS_SECRET="" \
+            --env VERBOSITY=2 \
+            --entrypoint "pm2 start processes.json --no-daemon" \
+            $NETSTATS_DOCKER_IMAGE
     fi
 
     # Get ENODE public address

--- a/nethermind/quickstart.sh
+++ b/nethermind/quickstart.sh
@@ -598,11 +598,13 @@ EOF
             --hostname $CONTAINER_NAME \
             -p 30303:30300/tcp \
             -p 30303:30300/udp \
-            -p 8545:8545 \
-            -p 8546:8546 \
             --restart always \
             $FUSE_CLIENT_DOCKER_IMAGE \
             --config $CONFIG \
+            --JsonRpc.Enabled true \
+            --JsonRpc.EnabledModules [Eth,Web3,Personal,Net,Parity] \
+            --JsonRpc.Host 0.0.0.0 \
+            --JsonRpc.Port 8545 \
             --KeyStore.PasswordFiles "keystore/pass.pwd" \
             --KeyStore.EnodeAccount "0x$PUBLIC_ADDRESS" \
             --KeyStore.UnlockAccounts "0x$PUBLIC_ADDRESS" \
@@ -614,6 +616,7 @@ EOF
         $PERMISSION_PREFIX docker run \
             --detach \
             --name "validator" \
+            --net container:$CONTAINER_NAME \
             --volume $KEYSTORE_DIR:/config/keys/FuseNetwork \
             --volume $KEYSTORE_DIR/pass.pwd:/config/pass.pwd \
             --restart always \


### PR DESCRIPTION
# Description

`quickstart.sh` file for Nethermind client is running `netstats` component near with blockchain client. It has by default entrypoint with pre - configured RPC configuration like `http://localhost:8545` which doesn't work in Docker network with the latest Docker release.

Need to do the next changes:

- Override `ENTRYPOINT` for `netstats` Docker container;
- Specify arguments via environment varialbes.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test A - Run standard node from scratch with the script;
- [ ] Test B - Run validator node from scratch with the script.