### PR TITLE
Increasing the max validator stake to 10M

### DIFF
--- a/contracts/ConsensusUtils.sol
+++ b/contracts/ConsensusUtils.sol
@@ -16,7 +16,7 @@ contract ConsensusUtils is EternalStorage, ValidatorSet {
   uint256 public constant DECIMALS = 10 ** 18;
   uint256 public constant MAX_VALIDATORS = 100;
   uint256 public constant MIN_STAKE = 1e23; // 100,000
-  uint256 public constant MAX_STAKE = 5e24; // 5,000,000
+  uint256 public constant MAX_STAKE = 1e25; // 10,000,000
   uint256 public constant CYCLE_DURATION_BLOCKS = 34560; // 48 hours [48*60*60/5]
   uint256 public constant SNAPSHOTS_PER_CYCLE = 0; // snapshot each 288 minutes [34560/10/60*5]
   uint256 public constant DEFAULT_VALIDATOR_FEE = 15e16; // 15%


### PR DESCRIPTION
subj.

constants are hardcoded in the code, so changing the constant should create the bytecode with the new constant value
