### PR TITLE
docs: Add snapshot download links

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,14 +106,13 @@ Make sure that your user is added to the `docker` user-group on _Unix_ systems, 
 
  To speed up node sync there are the snapshot download links.
 
- | Endpoint                       | Network | Direct link (latest)                                  |
- | ------------------------------ | ------- | ----------------------------------------------------- |
- | https://snapshot.fusespark.io  | Spark   | https://snapshot.fusespark.io/nethermind/database.zip |
- | https://snapshot.fuse.io       | Fuse    | https://snapshot.fuse.io/nethermind/database.zip      |
+ | Endpoint                       | Network | Type      | Direct link (latest)                                |
+ | ------------------------------ | ------- | --------- | --------------------------------------------------- |
+ | https://snapshot.fuse.io       | Fuse    | FastSync  | https://snapshot.fuse.io/openethereum/database.zip  |
 
  The archive file contains `database` folder, blockchain ledger, with n blocks depending on the snapshot date.
 
- > Note: Fuse still support OpenEthereum v3.3.5, Docker image `fusenet/node:2.0.2`. The snapshot direct link to the latest snapshot is https://snapshot.fuse.io/openethereum/database.zip.
+ > Note: Fuse snapshot compatible with OpenEthereum v3.3.5, Docker image `fusenet/node:2.0.2`.
 
 ### Using Quickstart
 

--- a/README.md
+++ b/README.md
@@ -99,8 +99,21 @@ Make sure that your user is added to the `docker` user-group on _Unix_ systems, 
 
 > Note:
 >
-> - Outbound traffic should be oppened for all IP addresses
-> - For Bootnode node role not necessarry to open RPC and WS ports, only P2P are required; for Validator node role WS and RPC ports should be openned on `localhost` and granted restricted access through IP whitelists
+> - Outbound traffic should be opened for all IP addresses
+> - For Bootnode node role not necessary to open RPC and WebSocket ports, only P2P are required; for Validator node role WebSocket and RPC ports should be opened on `localhost` and granted restricted access through IP whitelists
+
+### Snapshot
+
+ To speed up node sync there are the snapshot download links.
+
+ | Endpoint                       | Network | Direct link (latest)                                  |
+ | ------------------------------ | ------- | ----------------------------------------------------- |
+ | https://snapshot.fusespark.io  | Spark   | https://snapshot.fusespark.io/nethermind/database.zip |
+ | https://snapshot.fuse.io       | Fuse    | https://snapshot.fuse.io/nethermind/database.zip      |
+
+ The archive file contains `database` folder, blockchain ledger, with n blocks depending on the snapshot date.
+
+ > Note: Fuse still support OpenEthereum v3.3.5, Docker image `fusenet/node:2.0.2`. The snapshot direct link to the latest snapshot is https://snapshot.fuse.io/openethereum/database.zip.
 
 ### Using Quickstart
 

--- a/nethermind/README.md
+++ b/nethermind/README.md
@@ -71,9 +71,13 @@ Additionally, configure Nethermind monitoring by following the instructions [her
 
 ## Nethermind DB Snapshot
 
-| Network | Type     | Location                                                                     |
-| ------- | -------- | ---------------------------------------------------------------------------- |
-| Fuse    | FastSync | https://storage.cloud.google.com/fuse-node-snapshot/nethermind/database.zip  |
-| Spark   | FastSync | https://storage.cloud.google.com/spark-node-snapshot/nethermind/database.zip |
+To speed up node sync there are the snapshot download links.
+
+| Endpoint                       | Network | Type      | Direct link (latest)                                   |
+| ------------------------------ | ------- | --------- | ------------------------------------------------------ |
+| https://snapshot.fusespark.io  | Spark   | FastSync  | https://snapshot.fusespark.io/nethermind/database.zip  |
+| https://snapshot.fuse.io       | Fuse    | FastSync  | https://snapshot.fuse.io/nethermind/database.zip       |
+
+The archive file contains `database` folder, blockchain ledger, with `n` blocks depending on the snapshot date.
 
 ---


### PR DESCRIPTION
# Description

There are snapshot download links for both networks for community to spin up standard full nodes as fast as possible.

Summary:

- Added snapshot download links.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

There are no any tests.